### PR TITLE
Add scroll view to Abandon Penitence widget when text area overflows

### DIFF
--- a/Blasphemous.Framework.Penitence/Blasphemous.Framework.Penitence.csproj
+++ b/Blasphemous.Framework.Penitence/Blasphemous.Framework.Penitence.csproj
@@ -35,7 +35,7 @@
     <!-- Get export directories -->
     <PropertyGroup>
       <DevFolder>C:\Program Files (x86)\Steam\steamapps\common\Blasphemous\Modding\</DevFolder>
-      <PublishFolder>$(SolutionDir)\publish\$(TargetName)</PublishFolder>      
+      <PublishFolder>$(SolutionDir)\publish\$(TargetName)</PublishFolder>
     </PropertyGroup>
 
     <!-- Export to dev folder -->

--- a/Blasphemous.Framework.Penitence/Blasphemous.Framework.Penitence.csproj
+++ b/Blasphemous.Framework.Penitence/Blasphemous.Framework.Penitence.csproj
@@ -9,7 +9,7 @@
     <Authors>Damocles</Authors>
     <Company>Damocles</Company>
     <Description>Framework that allows other mods to implement custom penitences</Description>
-    <Version>0.2.1</Version>
+    <Version>0.2.2</Version>
 
     <TargetName>PenitenceFramework</TargetName>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -34,7 +34,7 @@
 
     <!-- Get export directories -->
     <PropertyGroup>
-      <DevFolder>C:\DEV\MOD\Blasphemous\Workspace\Blasphemous_Modded\Modding\</DevFolder>
+      <DevFolder>C:\Program Files (x86)\Steam\steamapps\common\Blasphemous\Modding\</DevFolder>
       <PublishFolder>$(SolutionDir)\publish\$(TargetName)</PublishFolder>      
     </PropertyGroup>
 

--- a/Blasphemous.Framework.Penitence/Blasphemous.Framework.Penitence.csproj
+++ b/Blasphemous.Framework.Penitence/Blasphemous.Framework.Penitence.csproj
@@ -34,8 +34,8 @@
 
     <!-- Get export directories -->
     <PropertyGroup>
-      <DevFolder>C:\Program Files (x86)\Steam\steamapps\common\Blasphemous\Modding\</DevFolder>
-      <PublishFolder>$(SolutionDir)\publish\$(TargetName)</PublishFolder>
+      <DevFolder>C:\DEV\MOD\Blasphemous\Workspace\Blasphemous_Modded\Modding\</DevFolder>
+      <PublishFolder>$(SolutionDir)\publish\$(TargetName)</PublishFolder>      
     </PropertyGroup>
 
     <!-- Export to dev folder -->

--- a/Blasphemous.Framework.Penitence/PenitencePatches.cs
+++ b/Blasphemous.Framework.Penitence/PenitencePatches.cs
@@ -169,12 +169,88 @@ class ChoosePenitenceWidgetActivate_Patch
     }
 }
 
-// Show custom penitence when abandoning
-[HarmonyPatch(typeof(AbandonPenitenceWidget), nameof(AbandonPenitenceWidget.UpdatePenitenceTextsAndDisplayedMedal))]
+// Display buttons and store action when opening widget
+[HarmonyPatch(typeof(AbandonPenitenceWidget), "Open", typeof(Action), typeof(Action))]
 class AbandonPenitenceWidgetOpen_Patch
 {
-    public static bool Prefix(Text ___penitenceTitle, Text ___penitenceInfoText, GameObject ___PE01Medal, GameObject ___PE02Medal, GameObject ___PE03Medal)
+    public static void Postfix(AbandonPenitenceWidget __instance)
     {
+
+        GameObject info = __instance.transform.Find("Info").gameObject;
+        if(null == info)
+        {
+            ModLog.Error("AbandonPenitenceWidgetOpen_Patch: 'Info' object not found!");
+            return;
+        }
+
+        if(null != info.transform.Find("Scroll View"))
+        {
+            ModLog.Info("AbandonPenitenceWidgetOpen_Patch: Scroll already added!");
+            return;
+        }
+
+        // Add scrollview and scrollbar
+        
+        GameObject scrollView = null;
+        GameObject scrollBar = null;
+        {
+            GameObject scrollViewSource = GameObject.Find("Game UI/Content/UI_CHOOSE_PENITENCE/Info/Scroll View");
+            if(null == scrollViewSource)
+            {
+                ModLog.Error("AbandonPenitenceWidgetOpen_Patch: 'Scroll view' object not found!");
+                return;
+            }
+
+            GameObject scrollBarSource = GameObject.Find("Game UI/Content/UI_CHOOSE_PENITENCE/Info/Scrollbar");
+            if(null == scrollBarSource)
+            {
+                ModLog.Error("AbandonPenitenceWidgetOpen_Patch: 'Scrollbar' object not found!");
+                return;
+            }
+
+            scrollView = GameObject.Instantiate(scrollViewSource, info.transform);
+            {
+                scrollView.name = "Scroll View";
+                //scrollView.transform.GetComponent<CustomScrollView>().
+            }
+
+            scrollBar = GameObject.Instantiate(scrollBarSource, info.transform);
+            {
+                scrollBar.name = "Scrollbar";
+                //scrollBar.transform.GetComponent<RectTransform>().anchoredPosition = new Vector2(20, 200);
+            }
+
+        }
+    }
+}
+
+// Show custom penitence when abandoning
+[HarmonyPatch(typeof(AbandonPenitenceWidget), nameof(AbandonPenitenceWidget.UpdatePenitenceTextsAndDisplayedMedal))]
+class AbandonPenitenceWidgetUpdateAndDisplay_Patch
+{
+    public static bool Prefix(AbandonPenitenceWidget __instance, Text ___penitenceTitle, Text ___penitenceInfoText, GameObject ___PE01Medal, GameObject ___PE02Medal, GameObject ___PE03Medal)
+    {
+        Transform scrollView = __instance.transform.Find("Info/Scroll View");
+        if(null == scrollView)
+        {
+            ModLog.Error("AbandonPenitenceWidgetUpdateAndDisplay_Patch: 'scrollView' object not found!");
+        }
+        else
+        {
+            ModLog.Info("AbandonPenitenceWidgetUpdateAndDisplay_Patch: 'scrollView' loaded!");
+        }
+
+        Transform scrollBar = __instance.transform.Find("Info/Scrollbar");
+        if(null == scrollBar)
+        {
+            ModLog.Error("AbandonPenitenceWidgetUpdateAndDisplay_Patch: 'scrollBar' object not found!");
+        }
+        else
+        {
+            ModLog.Info("AbandonPenitenceWidgetUpdateAndDisplay_Patch: 'scrollBar' loaded!");
+            scrollBar.gameObject.SetActive(true);
+        }
+
         if (Core.PenitenceManager.GetCurrentPenitence() is not ModPenitenceSystem modPenitence)
             return true;
 

--- a/Blasphemous.Framework.Penitence/PenitencePatches.cs
+++ b/Blasphemous.Framework.Penitence/PenitencePatches.cs
@@ -182,18 +182,18 @@ class AbandonPenitenceWidgetOpen_Patch
             // The UI elements have already been added, do nothing
             return true;
         }
-        
+
         GameObject info = __instance.transform.Find("Info").gameObject; // Container for the widget data
         if(null == info)
         {
             ModLog.Error("AbandonPenitenceWidgetOpen_Patch: 'Info' object not found!");
             return true;
-        }        
+        }
 
         // --- Add scrollview and scrollbar UI elements ---
         {   
             // --- Retrieve the UI elements from the Choose Penitence widget ---
-            
+
             GameObject scrollViewSource = GameObject.Find("Game UI/Content/UI_CHOOSE_PENITENCE/Info/Scroll View");
             if(null == scrollViewSource)
             {
@@ -238,11 +238,11 @@ class AbandonPenitenceWidgetOpen_Patch
 
                 // Get those transforms!
                 GameObject abandonText = info.transform.Find("Text").gameObject;
-                
+
                 RectTransform abandonTextRect = abandonText.transform.GetComponent<RectTransform>();
                 RectTransform scrollViewRect  = scrollView.transform.GetComponent<RectTransform>();
                 RectTransform scrollBarRect   = scrollBar.transform.GetComponent<RectTransform>();
-                
+
                 // For whatever reason, the regular text area is somewhat small. Let's make it bigger so
                 // we minimize the need for the scroll view              
                 abandonTextRect.anchoredPosition = new Vector2(18, 0);
@@ -276,7 +276,10 @@ class AbandonPenitenceWidgetUpdateAndDisplay_Patch
 
         ModPenitence currPenitence = Main.PenitenceFramework.GetPenitence(modPenitence.Id);
         if (currPenitence == null)
+        {
+            ModLog.Error($"AbandonPenitenceWidgetUpdateAndDisplay_Patch: Failed to retrieve valid penitence object for Id: '{modPenitence.Id}'");
             return false;
+        }
 
         Image medalImage = ___PE02Medal.GetComponentInChildren<Image>();
         Main.PenitenceFramework.Penitence2Image = medalImage.sprite;
@@ -295,7 +298,6 @@ class AbandonPenitenceWidgetUpdateAndDisplay_Patch
     {
         GameObject scrollView = __instance.transform.Find("Info/Scroll View").gameObject;
         GameObject scrollBar  = __instance.transform.Find("Info/Scrollbar").gameObject;
-        Text scrollText       = __instance.transform.Find("Info/Scroll View/Viewport/Content/Penitence_Text").GetComponent<Text>();
 
         // Check if we have our toys
         {
@@ -303,23 +305,19 @@ class AbandonPenitenceWidgetUpdateAndDisplay_Patch
             {
                 ModLog.Error("AbandonPenitenceWidgetUpdateAndDisplay_Patch: 'scrollView' object not found!");
                 return;
-            }            
+            }
 
             if(null == scrollBar)
             {
                 ModLog.Error("AbandonPenitenceWidgetUpdateAndDisplay_Patch: 'scrollBar' object not found!");
                 return;
             }
-
-            if(null == scrollText)
-            {
-                ModLog.Error("AbandonPenitenceWidgetUpdateAndDisplay_Patch: 'Penitence_Text' object not found!");
-                return;
-            }
         }
 
-        // Update text in scroll view area to match base text
-        scrollText.text = ___penitenceInfoText.text;
+        // Enable everything to make sure all operations work properly
+        ___penitenceInfoText.gameObject.SetActive(true);
+        scrollBar.SetActive(true);
+        scrollView.SetActive(true);
 
         // Check the final height of the text box vs the expected height
         float TextboxFinalHeight    = LayoutUtility.GetPreferredHeight(___penitenceInfoText.rectTransform);
@@ -327,20 +325,29 @@ class AbandonPenitenceWidgetUpdateAndDisplay_Patch
 
         if( TextboxFinalHeight <= TextboxExpectedHeight )
         {
-            ___penitenceInfoText.gameObject.SetActive(true);
+            // Text fits the text box, disable scroll view
             scrollBar.SetActive(false);
             scrollView.SetActive(false);
-
-            return; // Text fits the text box, do nothing else
         }
-                
-        // Replace basic textbox with scroll view        
-        {            
-            ___penitenceInfoText.gameObject.SetActive(false);
-            scrollBar.SetActive(true);
-            scrollView.SetActive(true);
+        else
+        {
+            // Replace basic textbox with scroll view
 
+            Text scrollText = __instance.transform.Find("Info/Scroll View/Viewport/Content/Penitence_Text").GetComponent<Text>();
+            if(null == scrollText)
+            {
+                ModLog.Error("AbandonPenitenceWidgetUpdateAndDisplay_Patch: 'Penitence_Text' object not found!");
+                return;
+            }
+
+            // Update text in scroll view area to match base text
+            scrollText.text = ___penitenceInfoText.text;
+
+            // Update scrollbar status
             scrollView.GetComponent<CustomScrollView>().NewContentSetted();
+
+            // Hide base text box last so it is available for the value assign above
+            ___penitenceInfoText.gameObject.SetActive(false);
         }
     }
 }


### PR DESCRIPTION
As reported on issue #2 , when the description of a custom penitence is too long, the text box in the Abandon Penitence widget will overflow, breaking the screen format.

This fix adds a functional scroll view element that will allow scrolling the text if needed.
Additionally, the Abandon Penitence widget text box is made larger by default, since it originally was made too small and did not take advantage of the available space.

The new positions and dimensions have been determined using the Unity editor:

![AbandonPenitence_PRSCR01](https://github.com/user-attachments/assets/f86ed9cc-e9de-4f92-907e-980bb98edc6f)
![AbandonPenitence_PRSCR02](https://github.com/user-attachments/assets/84da37c9-f322-4639-a6d0-b78f08815940)
![AbandonPenitence_PRSCR03](https://github.com/user-attachments/assets/7ef79978-33e5-45ce-b907-286f1dd7ac33)